### PR TITLE
Missing PHP package bug fix

### DIFF
--- a/vagrant_scripts/vagrant-init.sh
+++ b/vagrant_scripts/vagrant-init.sh
@@ -107,6 +107,7 @@ apt-get -y install php7.0-mysql php7.0-mysql php7.0-curl php7.0-gd php7.0-intl p
 apt-get -y install php-soap
 apt-get -y install php-redis
 apt-get -y install php-igbinary
+apt-get -y install php-bcmath
 #apt-get -y install phpmyadmin # @todo: get rid of interaction
 
 #


### PR DESCRIPTION
Bij het runnen van Vagrant up stopte het bash script net iets voor de installatie van de Magento files.
Na wat debugging en onderzoek kwam ik tot de conclusie dat er een php package miste. Deze regel is toegevoegd en lost de issue op.